### PR TITLE
fix issue#16 左侧model点击后，再次点击其他部位，再次点击左侧model，引起崩溃（必现）

### DIFF
--- a/XulDebugTool/ui/widget/model/Property.py
+++ b/XulDebugTool/ui/widget/model/Property.py
@@ -44,8 +44,10 @@ class Property(object):
         return self.parent
 
     def row(self):
-        if self.parent is not None:
-            return self.parent().child().index(self)
+        if self.parent is not None and isinstance(self.parent, Property):
+            return self.parent.child().index(self)
+        else:
+            return 0
 
     def createEditor(self, parent, option, index):
         raise NotImplementedError


### PR DESCRIPTION
cause: 因为两个数切换的时候调用了model的row函数,而row函数没有处理异常情况, 应该只处理Property.